### PR TITLE
Make DNS Requests case insensitive

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,26 @@
+name: Automatted Testing
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+     branches: [ main ]  
+
+jobs:
+
+  automatted-testing:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/pdnsmodel/model.go
+++ b/pdnsmodel/model.go
@@ -15,7 +15,7 @@ type Domain struct {
 type Record struct {
 	ID        uint `gorm:"primary_key"`
 	DomainId  sql.NullInt64
-	Name      string `gorm:"type:varchar(255)"`
+	Name      string `gorm:"type:varchar(255);not null"`
 	Type      string `gorm:"type:varchar(10)"`
 	Content   string `gorm:"type:text"`
 	Ttl       uint32

--- a/pdsql_test.go
+++ b/pdsql_test.go
@@ -44,6 +44,7 @@ func TestPowerDNSSQL(t *testing.T) {
 		{Name: "example.org", Type: "A", Content: "192.168.1.1", Ttl: 3600},
 		{Name: "cname1.example.org", Type: "CNAME", Content: "cname2.example.org.", Ttl: 3600},
 		{Name: "cname2.example.org", Type: "CNAME", Content: "example.org.", Ttl: 3600},
+		{Name: "nocase.example.org", Type: "CNAME", Content: "example.org.", Ttl: 3600},
 		{Name: "example.org", Type: "TXT", Content: "Example Response Text", Ttl: 3600},
 		{Name: "multi.example.org", Type: "A", Content: "192.168.1.2", Ttl: 7200},
 		{Name: "multi.example.org", Type: "A", Content: "192.168.1.3", Ttl: 7200},
@@ -91,6 +92,18 @@ func TestPowerDNSSQL(t *testing.T) {
 			expectedReply:  []string{"cname2.example.org.", "cname1.example.org.", "192.168.1.1"},
 			expectedErr:    nil,
 			rrReply: []dns.RR{&dns.CNAME{Target: "cname2.example.org."},
+				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("192.168.1.1")}},
+		},
+		{
+			testName:       "Case Insensitive Queries",
+			qname:          "NoCase.Example.ORG.",
+			qtype:          dns.TypeA,
+			expectedCode:   dns.RcodeSuccess,
+			expectedType:   []uint16{dns.TypeCNAME, dns.TypeA},
+			expectedHeader: []string{"nocase.example.org."},
+			expectedReply:  []string{"nocase.example.org.", "192.168.1.1"},
+			expectedErr:    nil,
+			rrReply: []dns.RR{
 				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("192.168.1.1")}},
 		},
 		{

--- a/setup.go
+++ b/setup.go
@@ -2,7 +2,7 @@ package pdsql
 
 import (
 	"github.com/glebarez/sqlite"
-	"github.com/wenerme/coredns-pdsql/pdnsmodel"
+	"pdsql/pdnsmodel"
 	"log"
 
 	"github.com/coredns/caddy"

--- a/setup.go
+++ b/setup.go
@@ -2,7 +2,7 @@ package pdsql
 
 import (
 	"github.com/glebarez/sqlite"
-	"pdsql/pdnsmodel"
+	"github.com/wenerme/coredns-pdsql/pdnsmodel"
 	"log"
 
 	"github.com/coredns/caddy"


### PR DESCRIPTION
According to the inquiry:

Closes #5 

DNS requests should be **case insensitive** which is not given for all database backends like _SQLite_ and _PostgreSQL_.

On the other hand the **in-built _CoreDNS_ `file` plugin** already features case insensitive DNS responses:
```plain
/ # dig -t a Mail.CoreDNS-File.local

; <<>> DiG 9.18.34 <<>> -t a Mail.CoreDNS-File.local
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 59306
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: a6f843044546a81c (echoed)
;; QUESTION SECTION:
;Mail.CoreDNS-File.local.	IN	A

;; ANSWER SECTION:
mail.coredns-file.local. 3600	IN	CNAME	postfix.coredns-file.local.
postfix.coredns-file.local. 3600 IN	A	172.53.0.6

;; AUTHORITY SECTION:
coredns-file.local.	3600	IN	NS	ns.coredns-file.local.

;; Query time: 0 msec
;; SERVER: 127.0.0.11#53(127.0.0.11) (UDP)
;; WHEN: Fri Mar 28 07:48:18 UTC 2025
;; MSG SIZE  rcvd: 137
```
So, with a `Corefile` like:
```plain
/usr/local/go/src/pdsql # cat /etc/coredns/Corefile
coredns-file.local {
	file /etc/coredns/zones/coredns-file-local.db

	whoami
	log
	errors
}
 
coredns-pdsql.local {
	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
		debug db
        	auto-migrate
	}

	whoami
	log
	errors
}

coredns-nocase.local {
	pdsql sqlite3 /var/lib/coredns/data/coredns.db {
		debug db
        	auto-migrate
	}

	whoami
	log
	errors
}

. {
	forward . /etc/resolv.conf
	log
}
```
The domains `coredns-file.local` and `coredns-nocase.local` have to behave identically.

This development enables the `pdsql` plugin to give now also the same response like the in-built `file` plugin:
```plain
/ # dig -t a Mail.CoreDNS-NoCase.local

; <<>> DiG 9.18.34 <<>> -t a Mail.CoreDNS-NoCase.local
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 46299
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 692c122920885046 (echoed)
;; QUESTION SECTION:
;Mail.CoreDNS-NoCase.local.	IN	A

;; ANSWER SECTION:
mail.coredns-nocase.local. 3600	IN	CNAME	postfix.coredns-nocase.local.
postfix.coredns-nocase.local. 3600 IN	A	172.53.0.6

;; Query time: 3 msec
;; SERVER: 127.0.0.11#53(127.0.0.11) (UDP)
;; WHEN: Fri Mar 28 07:48:51 UTC 2025
;; MSG SIZE  rcvd: 124
```
I also added a Test Case which tests the new behaviour:
```go
	testRecords := []*pdnsmodel.Record{
// ...	
		{Name: "nocase.example.org", Type: "CNAME", Content: "example.org.", Ttl: 3600},
// ...
	}
```
```go
		{
			testName:       "Case Insensitive Queries",
			qname:          "NoCase.Example.ORG.",
			qtype:          dns.TypeA,
			expectedCode:   dns.RcodeSuccess,
			expectedType:   []uint16{dns.TypeCNAME, dns.TypeA},
			expectedHeader: []string{"nocase.example.org."},
			expectedReply:  []string{"nocase.example.org.", "192.168.1.1"},
			expectedErr:    nil,
			rrReply: []dns.RR{
				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("192.168.1.1")}},
		},
```
