### PR TITLE
Support for Wildcard DNS Entries

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: Automatted Testing
+name: Automated Testing
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  automatted-testing:
+  automated-testing:
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   automatted-testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -44,8 +44,20 @@ test.:1053 {
     pdsql sqlite3 ./test.db {
         debug db
         auto-migrate
-    }
+    }   
 }
+
+coredns-pdsql.local {
+	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
+		debug db
+        auto-migrate
+	}
+
+	whoami
+	log
+	errors
+}
+
 ~~~
 
 Prepare data for test.
@@ -94,8 +106,4 @@ When queried for "first.example.test. A", CoreDNS will respond with:
 ;; ANSWER SECTION:
 first.example.test.	3600	IN	A	192.168.1.1
 ~~~
-
-## TODO
-
-* [x] support wildcard record
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ home: "https://github.com/wenerme/coredns-pdsql/blob/master/README.md"
 
 Use [gorm.io/gorm](https://gorm.io) to handle database, support many database as gorm dose.
 
+## Compatibility
+
+The plugin aims to be compatible with _PowerDNS_ backend databases.
+
+It also aims to provide the same feature scope as the `file` plugin or other _CoreDNS_ zone backends.
+
 ## Syntax
 
 ~~~ txt
@@ -47,7 +53,7 @@ test.:1053 {
     }   
 }
 
-coredns-pdsql.local {
+coredns-pdsql.local:1053 {
 	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
 		debug db
         auto-migrate

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ test.:1053 {
 
 coredns-pdsql.local.:1053 {
 	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
-		debug db
-        auto-migrate
+       debug db
+       auto-migrate
 	}
 
 	whoami
@@ -75,8 +75,8 @@ coredns-pdsql.local.:1053 {
  
 sub.coredns-pdsql.local.:1053 {
 	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
-		debug db
-        auto-migrate
+       debug db
+       auto-migrate
 	}
 
 	whoami

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Automatted Testing](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml/badge.svg)](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml)
 ---
-title: "pdsql
+title: "pdsql"
 description: "*pdsql* use powerdns generic sql as backend."
 weight: 10
 tags: [ "plugin" , "pdsql" ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Automatted Testing](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml/badge.svg)](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml)
 ---
 title: "pdsql"
 description: "*pdsql* use powerdns generic sql as backend."
@@ -9,6 +8,8 @@ date: "2017-12-09T10:26:00+08:00"
 repo: "https://github.com/wenerme/coredns-pdsql"
 home: "https://github.com/wenerme/coredns-pdsql/blob/master/README.md"
 ---
+
+[![Automatted Testing](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml/badge.svg)](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml)
 
 # pdsql
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+[![Automatted Testing](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml/badge.svg)](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml)
 ---
-title: "pdsql"
+title: "pdsql
 description: "*pdsql* use powerdns generic sql as backend."
 weight: 10
 tags: [ "plugin" , "pdsql" ]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ The plugin aims to be compatible with _PowerDNS_ backend databases.
 
 It also aims to provide the same feature scope as the `file` plugin or other _CoreDNS_ zone backends.
 
+It also supports multiple **sub zones** on **different backends** like:
+
+- `coredns-pdsql.local`
+- `sub.coredns-pdsql.local`
+- `file.sub.coredns-pdsql.local`
+
 ## Syntax
 
 ~~~ txt
@@ -54,11 +60,30 @@ test.:1053 {
     }   
 }
 
-coredns-pdsql.local:1053 {
+coredns-pdsql.local.:1053 {
 	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
 		debug db
         auto-migrate
 	}
+
+	whoami
+	log
+	errors
+}
+ 
+sub.coredns-pdsql.local.:1053 {
+	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
+		debug db
+        auto-migrate
+	}
+
+	whoami
+	log
+	errors
+}
+
+file.sub.coredns-pdsql.local.:1053 {
+	file /etc/coredns/zones/file-sub-coredns-pdsql-local.db
 
 	whoami
 	log

--- a/README.md
+++ b/README.md
@@ -63,35 +63,34 @@ test.:1053 {
 }
 
 coredns-pdsql.local.:1053 {
-	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
+   pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
        debug db
        auto-migrate
-	}
+   }
 
-	whoami
-	log
-	errors
+   whoami
+   log
+   errors
 }
  
 sub.coredns-pdsql.local.:1053 {
-	pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
+   pdsql postgres "host=db dbname=coredns user=coredns password=coredns.secret sslmode=disable" {
        debug db
        auto-migrate
-	}
+   }
 
-	whoami
-	log
-	errors
+   whoami
+   log
+   errors
 }
 
 file.sub.coredns-pdsql.local.:1053 {
-	file /etc/coredns/zones/file-sub-coredns-pdsql-local.db
+   file /etc/coredns/zones/file-sub-coredns-pdsql-local.db
 
-	whoami
-	log
-	errors
+   whoami
+   log
+   errors
 }
-
 ~~~
 
 Prepare data for test.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ repo: "https://github.com/wenerme/coredns-pdsql"
 home: "https://github.com/wenerme/coredns-pdsql/blob/master/README.md"
 ---
 
-[![Automatted Testing](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml/badge.svg)](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml)
+[![Automated Testing](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml/badge.svg)](https://github.com/wenerme/coredns-pdsql/actions/workflows/testing.yml)
 
 # pdsql
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ home: "https://github.com/wenerme/coredns-pdsql/blob/master/README.md"
 
 # pdsql
 
-*pdsql* use PowerDNS [generic sql](https://github.com/PowerDNS/pdns/tree/master/pdns/backends/gsql) as backend.
+`pdsql` - Connect _CoreDNS_ to _PowerDNS_ [`generic sql`](https://github.com/PowerDNS/pdns/tree/master/pdns/backends/gsql) 
+zone backends.
 
 Use [gorm.io/gorm](https://gorm.io) to handle database, support many database as gorm dose.
 

--- a/pdnsmodel/model.go
+++ b/pdnsmodel/model.go
@@ -13,15 +13,15 @@ type Domain struct {
 }
 
 type Record struct {
-	ID        uint `gorm:"primary_key"`
-	DomainId  uint
-	Name      string `gorm:"type:varchar(255);not null"`
-	Type      string `gorm:"type:varchar(10)"`
-	Content   string `gorm:"type:text"`
-	Ttl       uint32
-	Prio      int
+	ID         uint `gorm:"primary_key"`
+	DomainId   uint
+	Name       string `gorm:"type:varchar(255);not null"`
+	Type       string `gorm:"type:varchar(10)"`
+	Content    string `gorm:"type:text"`
+	Ttl        uint32
+	Prio       int
 	ChangeDate int
-	Disabled  bool
+	Disabled   bool
 	//ordername             VARCHAR(255) BINARY DEFAULT NULL,
 	//auth                  TINYINT(1) DEFAULT 1,
 }

--- a/pdnsmodel/model.go
+++ b/pdnsmodel/model.go
@@ -14,13 +14,13 @@ type Domain struct {
 
 type Record struct {
 	ID        uint `gorm:"primary_key"`
-	DomainId  sql.NullInt64
+	DomainId  uint
 	Name      string `gorm:"type:varchar(255);not null"`
 	Type      string `gorm:"type:varchar(10)"`
 	Content   string `gorm:"type:text"`
 	Ttl       uint32
 	Prio      int
-	ChangDate int
+	ChangeDate int
 	Disabled  bool
 	//ordername             VARCHAR(255) BINARY DEFAULT NULL,
 	//auth                  TINYINT(1) DEFAULT 1,

--- a/pdsql.go
+++ b/pdsql.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wenerme/coredns-pdsql/pdnsmodel"
+	"pdsql/pdnsmodel"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
@@ -32,7 +32,28 @@ func (pdb PowerDNSGenericSQLBackend) ServeDNS(ctx context.Context, w dns.Respons
 	a.Compress = true
 	a.Authoritative = true
 
-	var records []*pdnsmodel.Record
+	records, err := pdb.ResolveRequest(state.QName(), state.QType())
+
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			soa, err := pdb.ResolveSOA(state.QName())
+
+			if err != nil {
+				return dns.RcodeServerFailure, err
+			}
+
+			rr := new(dns.SOA)
+			rr.Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeSOA, Class: state.QClass()}
+
+			if ParseSOA(rr, soa.Content) {
+				a.Extra = append(a.Extra, rr)
+			}
+		} else {
+			return dns.RcodeServerFailure, err
+		}
+	}
+
+/*	[]*pdnsmodel.Record
 	query := pdnsmodel.Record{Name: strings.ToLower(state.QName()), Type: state.Type(), Disabled: false}
 
 	if strings.HasSuffix(query.Name, ".") && query.Name != "." {
@@ -60,12 +81,12 @@ func (pdb PowerDNSGenericSQLBackend) ServeDNS(ctx context.Context, w dns.Respons
 		}
 	} else {
 		if len(records) == 0 {
-			records, err = pdb.ResolveCNAMEs(state.QName())
+			records, err = pdb.ResolveCNAMEs(state.QName(), state.QType())
 			if err != nil {
 				return dns.RcodeServerFailure, err
 			}
 		}
-
+		*/
 		if len(records) == 0 {
 			records, err = pdb.SearchWildcard(state.QName(), state.QType())
 			if err != nil {
@@ -184,7 +205,8 @@ func (pdb PowerDNSGenericSQLBackend) ServeDNS(ctx context.Context, w dns.Respons
 				a.Answer = append(a.Answer, rr)
 			}
 		}
-	}
+	//}
+
 	if len(a.Answer) == 0 {
 		return plugin.NextOrFailure(pdb.Name(), pdb.Next, ctx, w, r)
 	}
@@ -192,8 +214,86 @@ func (pdb PowerDNSGenericSQLBackend) ServeDNS(ctx context.Context, w dns.Respons
 	return 0, w.WriteMsg(a)
 }
 
-func (pdb *PowerDNSGenericSQLBackend) ResolveCNAMEs(cname string) ([]*pdnsmodel.Record, error) {
-	resolveTypes := []string{"CNAME", "A", "AAA"}
+func (pdb *PowerDNSGenericSQLBackend) ResolveRequest(qname string, qtype uint16) ([]*pdnsmodel.Record, error) {
+	var resRecords []*pdnsmodel.Record
+	var err error
+
+	qname = strings.ToLower(qname)
+
+	if strings.HasSuffix(qname, ".") {
+		// remove last dot
+		qname = strings.TrimSuffix(qname, ".")
+	}
+
+	var queryRecords []pdnsmodel.Record
+	query := pdb.Model(&pdnsmodel.Record{}).
+		Where("name = ?", qname)
+
+	switch qtype {
+	case dns.TypeANY:
+		// Do not add any type query
+	case dns.TypeCNAME:
+		query = query.Where("type = ?", dns.TypeToString[qtype])
+	default:
+		resolveTypes := []string{"CNAME", dns.TypeToString[qtype]}
+		query = query.Where(map[string]interface{}{"type": &resolveTypes})
+	}
+
+	query = query.Where("disabled = ?", false)
+
+	if err := query.Find(&queryRecords).Error; err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("pdsql - ResolveRequest(): qry recs: %#v'\n", queryRecords)
+
+	if len(queryRecords) != 0 {
+		for recIndex, queryRec := range queryRecords {
+			// Save successful records
+			resRecords = append(resRecords, &queryRecords[recIndex])
+
+			// Resolve CNAME entries
+			if queryRec.Type == "CNAME" && qtype != dns.TypeANY {
+				if cnameRecords, err := pdb.ResolveCNAMEs(queryRec.Content, qtype); err == nil {
+					for _, r := range cnameRecords {
+						resRecords = append(resRecords, r)
+					}
+				} else {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return resRecords, err
+}
+
+func (pdb *PowerDNSGenericSQLBackend) ResolveSOA(qname string) (*pdnsmodel.Record, error) {
+	var soaRecord pdnsmodel.Record
+
+	qname = strings.ToLower(qname)
+
+	if strings.HasSuffix(qname, ".") {
+		// remove last dot
+		qname = strings.TrimSuffix(qname, ".")
+	}
+
+	query := pdb.Model(&soaRecord).
+		Where("name = ?", qname).
+		Where("type = ?", "SOA").
+		Where("disabled = ?", false)
+
+	if err := query.Find(&soaRecord).Error; err == nil {
+		fmt.Printf("pdsql - ResolveRequest(): soa rec: %#v'\n", soaRecord)
+
+		return &soaRecord, err
+	} else {
+		return nil, err
+	}
+}
+
+func (pdb *PowerDNSGenericSQLBackend) ResolveCNAMEs(cname string, qtype uint16) ([]*pdnsmodel.Record, error) {
+	var resolveTypes []string
 	resolveCNAME := true
 
 	var cnameRecords []*pdnsmodel.Record
@@ -206,28 +306,49 @@ func (pdb *PowerDNSGenericSQLBackend) ResolveCNAMEs(cname string) ([]*pdnsmodel.
 		cname = strings.TrimSuffix(cname, ".")
 	}
 
-	for resolveCNAME {
-		var cnameRecord = pdnsmodel.Record{Name: cname}
+	switch qtype {
+	case dns.TypeANY:
+		// Do not add any type query
+	case dns.TypeCNAME:
+		resolveTypes = []string{dns.TypeToString[qtype]}
+	default:
+		resolveTypes = []string{"CNAME", dns.TypeToString[qtype]}
+	}
 
-		if err := pdb.Where(&cnameRecord).Where(map[string]interface{}{"type": &resolveTypes}).Find(&cnameRecord).Error; err != nil {
+	for resolveCNAME {
+		var queryRecords []pdnsmodel.Record
+		query := pdb.Model(&pdnsmodel.Record{}).
+			Where("name = ?", cname)
+
+		if len(resolveTypes) != 0 {
+			query = query.Where(map[string]interface{}{"type": &resolveTypes})
+		}
+
+		query = query.Where("disabled = ?", false)
+
+		if err := query.Find(&queryRecords).Error; err != nil {
 			return nil, err
 		}
 
-		if cnameRecord.ID != 0 && cnameRecord.Content != "" {
-			// Save successful records
-			cnameRecords = append(cnameRecords, &cnameRecord)
+		fmt.Printf("pdsql - ResolveCNAMEs(): qry recs: %#v'\n", queryRecords)
 
-			// Resolve resursively
-			if cnameRecord.Type == "CNAME" {
-				// Update Search
-				cname = cnameRecord.Content
+		if len(queryRecords) != 0 {
+			for recIndex, queryRec := range queryRecords {
+				// Save successful records
+				cnameRecords = append(cnameRecords, &queryRecords[recIndex])
 
-				if strings.HasSuffix(cname, ".") {
-					// remove last dot
-					cname = strings.TrimSuffix(cname, ".")
+				// Resolve resursively
+				if queryRec.Type == "CNAME" {
+					// Update Search
+					cname = queryRec.Content
+
+					if strings.HasSuffix(cname, ".") {
+						// remove last dot
+						cname = strings.TrimSuffix(cname, ".")
+					}
+				} else {
+					resolveCNAME = false
 				}
-			} else {
-				resolveCNAME = false
 			}
 		} else {
 			resolveCNAME = false
@@ -237,13 +358,21 @@ func (pdb *PowerDNSGenericSQLBackend) ResolveCNAMEs(cname string) ([]*pdnsmodel.
 	return cnameRecords, err
 }
 
-func (pdb PowerDNSGenericSQLBackend) SearchWildcard(qname string, qtype uint16) (redords []*pdnsmodel.Record, err error) {
+func (pdb *PowerDNSGenericSQLBackend) SearchWildcard(qname string, qtype uint16) ([]*pdnsmodel.Record, error) {
 	// find domain, then find matched sub domain
-	name := strings.ToLower(qname)
-	qnameNoDot := name[:len(name)-1]
-	typ := dns.TypeToString[qtype]
-	name = qnameNoDot
-NEXT_ZONE:
+	searchName := strings.TrimSuffix(strings.ToLower(qname), ".")
+
+	domain, err := pdb.SearchDomain(qname)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if domain == nil {
+		return nil, nil
+	}
+
+	/*NEXT_ZONE:
 	if i := strings.IndexRune(name, '.'); i > 0 {
 		name = name[i+1:]
 	} else {
@@ -257,23 +386,94 @@ NEXT_ZONE:
 		}
 		return nil, err
 	}
+	*/
+	var astRecords []pdnsmodel.Record
+	query := pdb.Model(&pdnsmodel.Record{}).
+		Where("domain_id = ?", (*domain).ID).
+		Where("name LIKE ?", "*.%")
 
-	if err := pdb.Find(&redords, "domain_id = ? and ( ? = 'ANY' or type = ? ) and name like '%*%'", domain.ID, typ, typ).Error; err != nil {
+	switch qtype {
+	case dns.TypeANY:
+		// Do not add any type query
+	default:
+		typeValues := []string{"CNAME", dns.TypeToString[qtype]}
+		query = query.Where(map[string]interface{}{"type": &typeValues})
+	}
+
+	query = query.Where("disabled = ?", false)
+
+	if err := query.Find(&astRecords).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
 		}
 		return nil, err
 	}
 
+	fmt.Printf("pdsql - SearchWildcard(): res recs: %#v'\n", astRecords)
+
 	// filter
 	var matched []*pdnsmodel.Record
-	for _, v := range redords {
-		if WildcardMatch(qnameNoDot, v.Name) {
-			matched = append(matched, v)
+
+	for matchIndex, astRec := range astRecords {
+		if WildcardMatch(searchName, astRec.Name) {
+			astRecords[matchIndex].Name = searchName
+
+			matched = append(matched, &astRecords[matchIndex])
+
+			// Resolve CNAME entries
+			if astRec.Type == "CNAME" && qtype != dns.TypeANY {
+				if cnameRecords, err := pdb.ResolveCNAMEs(astRec.Content, qtype); err == nil {
+					for _, r := range cnameRecords {
+						matched = append(matched, r)
+					}
+				} else {
+					return nil, err
+				}
+			}
 		}
 	}
-	redords = matched
-	return
+
+	return matched, nil
+}
+
+func (pdb *PowerDNSGenericSQLBackend) SearchDomain(qname string) (*pdnsmodel.Domain, error) {
+	if strings.HasSuffix(qname, ".") {
+		qname = strings.TrimSuffix(qname, ".")
+	}
+
+	domainParts := dns.SplitDomainName(strings.ToLower(qname))
+	var domainSearch []string
+
+	for first := 0; first < len(domainParts)-1; first++ {
+		domain := strings.Join(domainParts[first:], ".")
+
+		fmt.Printf("pdsql - SearchDomain(): dom (last: %d): '%s'\n", first, domain)
+
+		domainSearch = append(domainSearch, domain)
+	}
+
+	fmt.Printf("pdsql - SearchDomain(): dom srh: %#v\n", domainSearch)
+
+	var domainMatches []pdnsmodel.Domain
+	var domainResult *pdnsmodel.Domain = nil
+	domainLength := -1
+
+	if err := pdb.Where(map[string]interface{}{"name": &domainSearch}).Find(&domainMatches).Error; err != nil {
+		return nil, err
+	}
+
+	if len(domainMatches) > 0 {
+		for matchIndex, domain := range domainMatches {
+			if domainLength == -1 || len(domain.Name) > domainLength {
+				domainResult = &domainMatches[matchIndex]
+				domainLength = len(domain.Name)
+			}
+		}
+	}
+
+	fmt.Printf("pdsql - SearchDomain(): res dom: %#v'\n", domainResult)
+
+	return domainResult, nil
 }
 
 func ParseSOA(rr *dns.SOA, line string) bool {
@@ -319,6 +519,33 @@ func WildcardMatch(s1, s2 string) bool {
 
 	l1 := dns.SplitDomainName(s1)
 	l2 := dns.SplitDomainName(s2)
+	len1 := len(l1)
+	len2 := len(l2)
+	asterisk := false
+	match := true
+
+	fmt.Printf("pdsql - WildcardMatch(): l1: %#v'\n", l1)
+	fmt.Printf("pdsql - WildcardMatch(): l2: %#v'\n", l2)
+
+	for last := 1; !asterisk && match && last <= len2; last++ {
+		match = bool(last <= len2 && last <= len1)
+
+		if match {
+			fmt.Printf("pdsql - WildcardMatch(): l1 '%s' == l2 '%s'\n", l1[len1-last], l2[len2-last])
+
+			// Everything matches after the asterisk
+			asterisk = bool(l2[len2-last] == "*")
+
+			if !asterisk {
+				// Compare the Domain Parts
+				match = bool(l1[len1-last] == l2[len2-last])
+			}
+		}
+	}
+
+	fmt.Printf("pdsql - WildcardMatch(): mtch: %#v\n", match)
+
+	return match
 
 	if len(l1) != len(l2) {
 		return false

--- a/pdsql.go
+++ b/pdsql.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"pdsql/pdnsmodel"
+	"github.com/wenerme/coredns-pdsql/pdnsmodel"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"

--- a/pdsql_test.go
+++ b/pdsql_test.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"testing"
 
+	//"database/sql"
+
 	pdsql "github.com/wenerme/coredns-pdsql"
 	"github.com/wenerme/coredns-pdsql/pdnsmodel"
 
@@ -40,21 +42,48 @@ func TestPowerDNSSQL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testRecords := []*pdnsmodel.Record{
-		{Name: "example.org", Type: "A", Content: "192.168.1.1", Ttl: 3600},
-		{Name: "cname1.example.org", Type: "CNAME", Content: "cname2.example.org.", Ttl: 3600},
-		{Name: "cname2.example.org", Type: "CNAME", Content: "example.org.", Ttl: 3600},
-		{Name: "nocase.example.org", Type: "CNAME", Content: "example.org.", Ttl: 3600},
-		{Name: "example.org", Type: "TXT", Content: "Example Response Text", Ttl: 3600},
-		{Name: "multi.example.org", Type: "A", Content: "192.168.1.2", Ttl: 7200},
-		{Name: "multi.example.org", Type: "A", Content: "192.168.1.3", Ttl: 7200},
-		{Name: "example.org", Type: "MX", Content: "10 mail.example.org.", Ttl: 3600},
-		{Name: "example.org", Type: "MX", Content: "20 mail2.example.org.", Ttl: 3600},
-		{Name: "_xmpp._tcp.example.org", Type: "SRV", Content: "10 10 5269 example.org.", Ttl: 3600},
+	fmt.Println("pdsql - TestPowerDNSSQL(): Migration done.")
+
+	testDomains := map[string]*pdnsmodel.Domain{
+		"example.org": &pdnsmodel.Domain{Name: "example.org", Type: "NATIVE"},
+	}
+
+	for n, d := range testDomains {
+		fmt.Printf("pdsql - TestPowerDNSSQL(): dom '%s': %#v\n", n, d)
+
+		if err := p.DB.Create(d).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fmt.Println("pdsql - TestPowerDNSSQL(): Domains created.")
+
+	//var domainID uint = testDomains["example.org"].ID
+
+	//testDomains["example.org"].ID = 1
+
+	//domainID.Scan((*testDomains["example.org"]).ID)
+
+	testRecords := []pdnsmodel.Record{
+		{Name: "example.org", DomainId: testDomains["example.org"].ID, Type: "A", Content: "192.168.1.1", Ttl: 3600},
+		{Name: "example.org", DomainId: testDomains["example.org"].ID, Type: "AAAA", Content: "::ffff:c0a8:101", Ttl: 3600},
+		{Name: "*.example.org", DomainId: testDomains["example.org"].ID, Type: "CNAME", Content: "example.org", Ttl: 3600},
+		{Name: "cname1.example.org", DomainId: testDomains["example.org"].ID, Type: "CNAME", Content: "cname2.example.org", Ttl: 3600},
+		{Name: "cname2.example.org", DomainId: testDomains["example.org"].ID, Type: "CNAME", Content: "example.org", Ttl: 3600},
+		{Name: "nocase.example.org", DomainId: testDomains["example.org"].ID, Type: "CNAME", Content: "example.org", Ttl: 3600},
+		{Name: "example.org", DomainId: testDomains["example.org"].ID, Type: "TXT", Content: "Example Response Text", Ttl: 3600},
+		{Name: "multi.example.org", DomainId: testDomains["example.org"].ID, Type: "A", Content: "192.168.1.2", Ttl: 7200},
+		{Name: "multi.example.org", DomainId: testDomains["example.org"].ID, Type: "A", Content: "192.168.1.3", Ttl: 7200},
+		{Name: "example.org", DomainId: testDomains["example.org"].ID, Type: "MX", Content: "10 mail.example.org", Ttl: 3600},
+		{Name: "example.org", DomainId: testDomains["example.org"].ID, Type: "MX", Content: "20 mail2.example.org", Ttl: 3600},
+		{Name: "example.org", DomainId: testDomains["example.org"].ID, Type: "MX", Content: "mail3.example.org", Prio: 30, Ttl: 3600},
+		{Name: "_xmpp._tcp.example.org", DomainId: testDomains["example.org"].ID, Type: "SRV", Content: "10 10 5269 example.org.", Ttl: 3600},
 	}
 
 	for _, r := range testRecords {
-		if err := p.DB.Create(r).Error; err != nil {
+		fmt.Printf("pdsql - TestPowerDNSSQL(): rec '%s': %#v\n", r.Name, r)
+
+		if err := p.DB.Create(&r).Error; err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -72,15 +101,26 @@ func TestPowerDNSSQL(t *testing.T) {
 			rrReply:        []dns.RR{&dns.A{A: net.ParseIP("192.168.1.1")}},
 		},
 		{
+			testName:       "Type AAAA Request",
+			qname:          "example.org.",
+			qtype:          dns.TypeAAAA,
+			expectedCode:   dns.RcodeSuccess,
+			expectedType:   []uint16{dns.TypeAAAA},
+			expectedHeader: []string{"example.org."},
+			expectedReply:  []string{"::ffff:c0a8:101"},
+			expectedErr:    nil,
+			rrReply:        []dns.RR{&dns.AAAA{AAAA: net.ParseIP("::ffff:c0a8:101")}},
+		},
+		{
 			testName:       "Type CNAME Request",
 			qname:          "cname1.example.org.",
 			qtype:          dns.TypeCNAME,
 			expectedCode:   dns.RcodeSuccess,
-			expectedType:   []uint16{dns.TypeCNAME},
-			expectedHeader: []string{"cname1.example.org."},
-			expectedReply:  []string{"cname2.example.org."},
+			expectedType:   []uint16{dns.TypeCNAME, dns.TypeCNAME},
+			expectedHeader: []string{"cname1.example.org.", "cname2.example.org."},
+			expectedReply:  []string{"cname2.example.org.", "example.org."},
 			expectedErr:    nil,
-			rrReply:        []dns.RR{&dns.CNAME{Target: "cname2.example.org."}},
+			rrReply:        []dns.RR{&dns.CNAME{Target: "cname2.example.org."}, &dns.CNAME{Target: "example.org."}},
 		},
 		{
 			testName:       "CNAME resolves to A Record",
@@ -95,6 +135,18 @@ func TestPowerDNSSQL(t *testing.T) {
 				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("192.168.1.1")}},
 		},
 		{
+			testName:       "CNAME resolves to AAAA Record",
+			qname:          "cname1.example.org.",
+			qtype:          dns.TypeAAAA,
+			expectedCode:   dns.RcodeSuccess,
+			expectedType:   []uint16{dns.TypeCNAME, dns.TypeCNAME, dns.TypeAAAA},
+			expectedHeader: []string{"cname1.example.org."},
+			expectedReply:  []string{"cname2.example.org.", "cname1.example.org.", "::ffff:c0a8:101"},
+			expectedErr:    nil,
+			rrReply: []dns.RR{&dns.CNAME{Target: "cname2.example.org."},
+				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("::ffff:c0a8:101")}},
+		},
+		{
 			testName:       "Case Insensitive Queries",
 			qname:          "NoCase.Example.ORG.",
 			qtype:          dns.TypeA,
@@ -105,6 +157,42 @@ func TestPowerDNSSQL(t *testing.T) {
 			expectedErr:    nil,
 			rrReply: []dns.RR{
 				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("192.168.1.1")}},
+		},
+		{
+			testName:       "Wildcard ANY Request",
+			qname:          "NOT.Exists.Example.ORG.",
+			qtype:          dns.TypeANY,
+			expectedCode:   dns.RcodeSuccess,
+			expectedType:   []uint16{dns.TypeCNAME},
+			expectedHeader: []string{"not.exists.example.org."},
+			expectedReply:  []string{"example.org."},
+			expectedErr:    nil,
+			rrReply: []dns.RR{
+				&dns.CNAME{Target: "example.org."}},
+		},
+		{
+			testName:       "Wildcard A Request",
+			qname:          "NOT.Exists.Example.ORG.",
+			qtype:          dns.TypeA,
+			expectedCode:   dns.RcodeSuccess,
+			expectedType:   []uint16{dns.TypeCNAME, dns.TypeA},
+			expectedHeader: []string{"not.exists.example.org."},
+			expectedReply:  []string{"example.org.", "192.168.1.1"},
+			expectedErr:    nil,
+			rrReply: []dns.RR{
+				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("192.168.1.1")}},
+		},
+		{
+			testName:       "Wildcard AAAA Request",
+			qname:          "NOT.Exists.Example.ORG.",
+			qtype:          dns.TypeAAAA,
+			expectedCode:   dns.RcodeSuccess,
+			expectedType:   []uint16{dns.TypeCNAME, dns.TypeAAAA},
+			expectedHeader: []string{"not.exists.example.org."},
+			expectedReply:  []string{"example.org.", "::ffff:c0a8:101"},
+			expectedErr:    nil,
+			rrReply: []dns.RR{
+				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("::ffff:c0a8:101")}},
 		},
 		{
 			testName:       "Type TXT Request",
@@ -134,12 +222,13 @@ func TestPowerDNSSQL(t *testing.T) {
 			qname:          "example.org",
 			qtype:          dns.TypeMX,
 			expectedCode:   dns.RcodeSuccess,
-			expectedType:   []uint16{dns.TypeMX, dns.TypeMX},
-			expectedHeader: []string{"example.org.", "example.org."},
-			expectedReply:  []string{"10 mail.example.org.", "20 mail2.example.org."},
+			expectedType:   []uint16{dns.TypeMX, dns.TypeMX, dns.TypeMX},
+			expectedHeader: []string{"example.org.", "example.org.", "example.org."},
+			expectedReply:  []string{"10 mail.example.org.", "20 mail2.example.org.", "30 mail3.example.org."},
 			expectedErr:    nil,
 			rrReply: []dns.RR{&dns.MX{Mx: "mail.example.org.", Preference: 10},
-				&dns.MX{Mx: "mail2.example.org.", Preference: 20}},
+				&dns.MX{Mx: "mail2.example.org.", Preference: 20},
+				&dns.MX{Mx: "mail3.example.org.", Preference: 30}},
 		},
 		{
 			testName:       "Type SRV Request",
@@ -172,6 +261,12 @@ func TestPowerDNSSQL(t *testing.T) {
 
 		if observed.Msg.Answer == nil {
 			t.Errorf("Test '%s': Expected answer section, but got nil", tc.testName)
+		}
+
+		fmt.Printf("test '%s': asw: %#v'\n", tc.testName, observed.Msg.Answer)
+
+		for i, rr := range observed.Msg.Answer {
+			fmt.Printf("test '%s': asw[%d]: %#v'\n", tc.testName, i, rr)
 		}
 
 		if len(tc.expectedReply) != len(observed.Msg.Answer) {
@@ -264,6 +359,7 @@ func TestWildcardMatch(t *testing.T) {
 		{"a.example.org.", "a.example.org.", true},
 		{"*.example.org.", "a.example.org.", true},
 		{"*.example.org.", "abcd.example.org.", true},
+		{"*.example.org.", "not.exist.example.org.", true},
 	}
 
 	for i, tc := range tests {

--- a/pdsql_test.go
+++ b/pdsql_test.go
@@ -5,8 +5,6 @@ import (
 	"net"
 	"testing"
 
-	//"database/sql"
-
 	pdsql "github.com/wenerme/coredns-pdsql"
 	"github.com/wenerme/coredns-pdsql/pdnsmodel"
 

--- a/pdsql_test.go
+++ b/pdsql_test.go
@@ -44,7 +44,7 @@ func TestPowerDNSSQL(t *testing.T) {
 		"example.org": &pdnsmodel.Domain{Name: "example.org", Type: "NATIVE"},
 	}
 
-	for n, d := range testDomains {
+	for _, d := range testDomains {
 		if err := p.DB.Create(d).Error; err != nil {
 			t.Fatal(err)
 		}

--- a/pdsql_test.go
+++ b/pdsql_test.go
@@ -40,27 +40,15 @@ func TestPowerDNSSQL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Println("pdsql - TestPowerDNSSQL(): Migration done.")
-
 	testDomains := map[string]*pdnsmodel.Domain{
 		"example.org": &pdnsmodel.Domain{Name: "example.org", Type: "NATIVE"},
 	}
 
 	for n, d := range testDomains {
-		fmt.Printf("pdsql - TestPowerDNSSQL(): dom '%s': %#v\n", n, d)
-
 		if err := p.DB.Create(d).Error; err != nil {
 			t.Fatal(err)
 		}
 	}
-
-	fmt.Println("pdsql - TestPowerDNSSQL(): Domains created.")
-
-	//var domainID uint = testDomains["example.org"].ID
-
-	//testDomains["example.org"].ID = 1
-
-	//domainID.Scan((*testDomains["example.org"]).ID)
 
 	testRecords := []pdnsmodel.Record{
 		{Name: "example.org", DomainId: testDomains["example.org"].ID, Type: "A", Content: "192.168.1.1", Ttl: 3600},
@@ -79,8 +67,6 @@ func TestPowerDNSSQL(t *testing.T) {
 	}
 
 	for _, r := range testRecords {
-		fmt.Printf("pdsql - TestPowerDNSSQL(): rec '%s': %#v\n", r.Name, r)
-
 		if err := p.DB.Create(&r).Error; err != nil {
 			t.Fatal(err)
 		}
@@ -261,12 +247,6 @@ func TestPowerDNSSQL(t *testing.T) {
 			t.Errorf("Test '%s': Expected answer section, but got nil", tc.testName)
 		}
 
-		fmt.Printf("test '%s': asw: %#v'\n", tc.testName, observed.Msg.Answer)
-
-		for i, rr := range observed.Msg.Answer {
-			fmt.Printf("test '%s': asw[%d]: %#v'\n", tc.testName, i, rr)
-		}
-
 		if len(tc.expectedReply) != len(observed.Msg.Answer) {
 			t.Errorf("Test '%s': Expected status len %d, but got %d", tc.testName, len(tc.expectedReply), len(observed.Msg.Answer))
 		}
@@ -282,7 +262,6 @@ func TestPowerDNSSQL(t *testing.T) {
 			if actual != expected {
 				t.Errorf("Test '%s' - Answer [%d]: Expected answer %s, but got %s", tc.testName, i, expected, actual)
 			}
-
 		}
 
 		for i, testExpected := range tc.rrReply {

--- a/setup.go
+++ b/setup.go
@@ -2,8 +2,8 @@ package pdsql
 
 import (
 	"github.com/glebarez/sqlite"
-	"github.com/wenerme/coredns-pdsql/pdnsmodel"
 	"log"
+	"pdsql/pdnsmodel"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -100,5 +100,5 @@ func setup(c *caddy.Controller) error {
 }
 
 func (pdb PowerDNSGenericSQLBackend) AutoMigrate() error {
-	return pdb.DB.AutoMigrate(&pdnsmodel.Record{}, &pdnsmodel.Domain{})
+	return pdb.DB.AutoMigrate(&pdnsmodel.Domain{}, &pdnsmodel.Record{})
 }

--- a/setup.go
+++ b/setup.go
@@ -2,8 +2,8 @@ package pdsql
 
 import (
 	"github.com/glebarez/sqlite"
-	"log"
 	"github.com/wenerme/coredns-pdsql/pdnsmodel"
+	"log"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"

--- a/setup.go
+++ b/setup.go
@@ -3,7 +3,7 @@ package pdsql
 import (
 	"github.com/glebarez/sqlite"
 	"log"
-	"pdsql/pdnsmodel"
+	"github.com/wenerme/coredns-pdsql/pdnsmodel"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"


### PR DESCRIPTION
Requests like `does.not.exist.sub.coredns-pdsql.local` is matched by `*.sub.coredns-pdsql.local`
```plain
/ # dig does.not.exist.sub.coredns-pdsql.local

; <<>> DiG 9.18.34 <<>> does.not.exist.sub.coredns-pdsql.local
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 9333
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 3
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: d20ecbfe68dcaec0 (echoed)
;; QUESTION SECTION:
;does.not.exist.sub.coredns-pdsql.local.	IN A

;; ADDITIONAL SECTION:
does.not.exist.sub.coredns-pdsql.local.	0 IN A	172.53.0.4
_udp.does.not.exist.sub.coredns-pdsql.local. 0 IN SRV 0 0 59497 .

;; Query time: 3 msec
;; SERVER: 127.0.0.11#53(127.0.0.11) (UDP)
;; WHEN: Sun Apr 20 12:07:41 UTC 2025
;; MSG SIZE  rcvd: 119
```
with fewer SQL lookups:
```plain
2025/04/20 12:07:41 /usr/local/go/src/pdsql/pdsql.go:208
[1.227ms] [rows:0] SELECT * FROM "records" WHERE name = 'does.not.exist.sub.coredns-pdsql.local' AND "type" IN ('CNAME','A') AND disabled = false

2025/04/20 12:07:41 /usr/local/go/src/pdsql/pdsql.go:399
[0.708ms] [rows:2] SELECT * FROM "domains" WHERE "name" IN ('does.not.exist.sub.coredns-pdsql.local','not.exist.sub.coredns-pdsql.local','exist.sub.coredns-pdsql.local','sub.coredns-pdsql.local','coredns-pdsql.local')

2025/04/20 12:07:41 /usr/local/go/src/pdsql/pdsql.go:350
[2.018ms] [rows:0] SELECT * FROM "records" WHERE domain_id = 3 AND name LIKE '*.%' AND "type" IN ('CNAME','A') AND disabled = false
[INFO] 172.53.0.4:59497 - 9333 "A IN does.not.exist.sub.coredns-pdsql.local. udp 79 false 1232" NOERROR qr,aa,rd 172 0.004384246s
```
Additionally `CNAME` and `ANY` requests are solved in the same way as they are resolved by the `file` plugin.

We only return `` records when they are specifically requested:
```plain
/ # dig -t aaaa not.exists.coredns-nocase.local

; <<>> DiG 9.18.34 <<>> -t aaaa not.exists.coredns-nocase.local
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 42376
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 2a431dea46d6dccb (echoed)
;; QUESTION SECTION:
;not.exists.coredns-nocase.local. IN	AAAA

;; ANSWER SECTION:
not.exists.coredns-nocase.local. 3600 IN CNAME	coredns-nocase.local.
coredns-nocase.local.	3600	IN	AAAA	::ffff:172.53.0.7

;; Query time: 0 msec
;; SERVER: 127.0.0.11#53(127.0.0.11) (UDP)
;; WHEN: Sun Apr 20 10:06:00 UTC 2025
;; MSG SIZE  rcvd: 114
```
```plain
/ # dig not.exists.coredns-nocase.local

; <<>> DiG 9.18.34 <<>> not.exists.coredns-nocase.local
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 45164
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 5294bd8d35a02a02 (echoed)
;; QUESTION SECTION:
;not.exists.coredns-nocase.local. IN	A

;; ANSWER SECTION:
not.exists.coredns-nocase.local. 3600 IN CNAME	coredns-nocase.local.
coredns-nocase.local.	3600	IN	A	172.53.0.7

;; Query time: 3 msec
;; SERVER: 127.0.0.11#53(127.0.0.11) (UDP)
;; WHEN: Sun Apr 20 10:08:05 UTC 2025
;; MSG SIZE  rcvd: 102
```
```plain
/ # dig -t any not.exists.coredns-nocase.local

; <<>> DiG 9.18.34 <<>> -t any not.exists.coredns-nocase.local
;; global options: +cmd
;; Got answer:
;; WARNING: .local is reserved for Multicast DNS
;; You are currently testing what happens when an mDNS query is leaked to DNS
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 19704
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 6b5adadf0212e357 (echoed)
;; QUESTION SECTION:
;not.exists.coredns-nocase.local. IN	ANY

;; ANSWER SECTION:
not.exists.coredns-nocase.local. 3600 IN CNAME	coredns-nocase.local.

;; Query time: 3 msec
;; SERVER: 127.0.0.11#53(127.0.0.11) (TCP)
;; WHEN: Sun Apr 20 10:09:28 UTC 2025
;; MSG SIZE  rcvd: 86
```
`ANY` request will not resolve `CNAME` records because there could mix up records.

Additionally the Test Cases have been extended with `AAAA` request test cases.
```go
                {
			testName:       "Type AAAA Request",
			qname:          "example.org.",
			qtype:          dns.TypeAAAA,
			expectedCode:   dns.RcodeSuccess,
			expectedType:   []uint16{dns.TypeAAAA},
			expectedHeader: []string{"example.org."},
			expectedReply:  []string{"::ffff:c0a8:101"},
			expectedErr:    nil,
			rrReply:        []dns.RR{&dns.AAAA{AAAA: net.ParseIP("::ffff:c0a8:101")}},
		}
// ...
                {
			testName:       "CNAME resolves to AAAA Record",
			qname:          "cname1.example.org.",
			qtype:          dns.TypeAAAA,
			expectedCode:   dns.RcodeSuccess,
			expectedType:   []uint16{dns.TypeCNAME, dns.TypeCNAME, dns.TypeAAAA},
			expectedHeader: []string{"cname1.example.org."},
			expectedReply:  []string{"cname2.example.org.", "cname1.example.org.", "::ffff:c0a8:101"},
			expectedErr:    nil,
			rrReply: []dns.RR{&dns.CNAME{Target: "cname2.example.org."},
				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("::ffff:c0a8:101")}},
		},
// ...
                {
			testName:       "Wildcard ANY Request",
			qname:          "NOT.Exists.Example.ORG.",
			qtype:          dns.TypeANY,
			expectedCode:   dns.RcodeSuccess,
			expectedType:   []uint16{dns.TypeCNAME},
			expectedHeader: []string{"not.exists.example.org."},
			expectedReply:  []string{"example.org."},
			expectedErr:    nil,
			rrReply: []dns.RR{
				&dns.CNAME{Target: "example.org."}},
		},
		{
			testName:       "Wildcard A Request",
			qname:          "NOT.Exists.Example.ORG.",
			qtype:          dns.TypeA,
			expectedCode:   dns.RcodeSuccess,
			expectedType:   []uint16{dns.TypeCNAME, dns.TypeA},
			expectedHeader: []string{"not.exists.example.org."},
			expectedReply:  []string{"example.org.", "192.168.1.1"},
			expectedErr:    nil,
			rrReply: []dns.RR{
				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("192.168.1.1")}},
		},
		{
			testName:       "Wildcard AAAA Request",
			qname:          "NOT.Exists.Example.ORG.",
			qtype:          dns.TypeAAAA,
			expectedCode:   dns.RcodeSuccess,
			expectedType:   []uint16{dns.TypeCNAME, dns.TypeAAAA},
			expectedHeader: []string{"not.exists.example.org."},
			expectedReply:  []string{"example.org.", "::ffff:c0a8:101"},
			expectedErr:    nil,
			rrReply: []dns.RR{
				&dns.CNAME{Target: "example.org."}, &dns.A{A: net.ParseIP("::ffff:c0a8:101")}},
		},		
```
```go
func TestWildcardMatch(t *testing.T) {
	tests := []struct {
		pattern  string
		name     string
		expected bool
	}{
// ...
                   {"*.example.org.", "not.exist.example.org.", true},
        }
// ...
}
```

This closes the issues:
 - Closes #13
 - Closes #14 